### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 DocuMCP is an intelligent Model Context Protocol (MCP) server that revolutionizes documentation deployment for open-source projects. It provides deep repository analysis, intelligent static site generator recommendations, and automated GitHub Pages deployment workflows.
 
+<a href="https://glama.ai/mcp/servers/@tosin2013/documcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tosin2013/documcp/badge" alt="documcp MCP server" />
+</a>
+
 ## TL;DR
 
 DocuMCP analyzes your repository, recommends the perfect static site generator (Jekyll, Hugo, Docusaurus, MkDocs, or Eleventy), creates professional documentation structure following Diataxis principles, and deploys it automatically to GitHub Pages. Just say "analyze my repository and deploy documentation" to get started.


### PR DESCRIPTION
This PR adds a badge for the [documcp](https://glama.ai/mcp/servers/@tosin2013/documcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@tosin2013/documcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tosin2013/documcp/badge" alt="documcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.