### PR TITLE
feat(watcher): persist watcher state to JSONL and add integration tests (#113)

### DIFF
--- a/src/utils/change-watcher.ts
+++ b/src/utils/change-watcher.ts
@@ -55,6 +55,69 @@ export interface ChangeWatcherResult {
   events: ChangeEvent[];
 }
 
+/**
+ * Persisted watcher state (issue #113).
+ *
+ * Stored as JSONL in `.documcp/watcher-state.jsonl` so each successful
+ * detection appends a single line. On startup we read the LAST line to
+ * recover the most recent state. JSONL is the right shape here because:
+ *
+ *   1. Append-only writes are atomic at the line level on POSIX, so we
+ *      don't have to do read-modify-write that could lose data on crash.
+ *   2. The full history of a long-running watcher is preserved for free,
+ *      which is useful for debugging "why did this drift event fire?"
+ *      without requiring a separate audit log.
+ *   3. It mirrors the JSONL convention already used by `kg-storage.ts`
+ *      and the memory layer (entities/relationships JSONL files).
+ *
+ * Schema versioning: every record carries `version` so we can change the
+ * shape later without breaking older state files (we'd just ignore lines
+ * with unknown versions and start fresh).
+ */
+export interface WatcherState {
+  /** Schema version — bump on incompatible changes. */
+  version: typeof WATCHER_STATE_VERSION;
+  /** ISO timestamp of the most recent successful detection run. */
+  lastDetectionAt: string | null;
+  /** Snapshot timestamp used as the "last known good" baseline. */
+  lastSnapshotId: string | null;
+  /** Cumulative count of change events processed since first run. */
+  eventCount: number;
+  /** Most recent N event types — bounded ring buffer for diagnostics. */
+  recentEventTypes: ChangeTrigger[];
+}
+
+/**
+ * Bumped only on incompatible schema changes. Old state files with a
+ * different version are ignored on load and a fresh run starts.
+ */
+export const WATCHER_STATE_VERSION = "1" as const;
+
+/** Filename written under `snapshotDir` (or `.documcp/`). */
+export const WATCHER_STATE_FILENAME = "watcher-state.jsonl";
+
+/** Maximum number of recent event types to retain in `recentEventTypes`. */
+const RECENT_EVENT_TYPES_LIMIT = 10;
+
+/**
+ * Runtime validator for a parsed JSON object claiming to be a WatcherState.
+ * We accept records whose required fields are present and have the right
+ * primitive types; we tolerate extra unknown fields so we don't break on
+ * future schema additions that aren't actually incompatible.
+ */
+function isWatcherStateRecord(value: unknown): value is WatcherState {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.version === "string" &&
+    (v.lastDetectionAt === null || typeof v.lastDetectionAt === "string") &&
+    (v.lastSnapshotId === null || typeof v.lastSnapshotId === "string") &&
+    typeof v.eventCount === "number" &&
+    Array.isArray(v.recentEventTypes) &&
+    v.recentEventTypes.every((t) => typeof t === "string")
+  );
+}
+
 interface DriftDetectorLike {
   initialize(): Promise<void>;
   createSnapshot(projectPath: string, docsPath: string): Promise<DriftSnapshot>;
@@ -101,6 +164,18 @@ export class ChangeWatcher {
   private latestSnapshot: DriftSnapshot | null = null;
   private isRunningDetection = false;
   private stopped = false;
+  /**
+   * In-memory mirror of the most recent persisted record. Re-hydrated from
+   * disk on `start()` and updated after every successful `runDetection()`.
+   * Always non-null after `start()` returns.
+   */
+  private currentState: WatcherState = {
+    version: WATCHER_STATE_VERSION,
+    lastDetectionAt: null,
+    lastSnapshotId: null,
+    eventCount: 0,
+    recentEventTypes: [],
+  };
 
   constructor(options: ChangeWatcherOptions, deps: ChangeWatcherDeps = {}) {
     const triggerOnCommit = options.triggerOnCommit ?? true;
@@ -127,6 +202,18 @@ export class ChangeWatcher {
 
   async start(): Promise<void> {
     this.stopped = false;
+    // Rehydrate before initializing the detector so corrupt/missing state
+    // is handled before we do any expensive work. A failure here never
+    // throws — the recovery path is "just start fresh".
+    const persisted = await this.loadState();
+    if (persisted) {
+      this.currentState = persisted;
+      this.logInfo(
+        `Rehydrated watcher state: ${persisted.eventCount} prior event(s), last detection ${
+          persisted.lastDetectionAt ?? "never"
+        }`,
+      );
+    }
     await this.ensureDetector();
     await this.ensureBaseline();
     this.startFsWatcher();
@@ -160,6 +247,10 @@ export class ChangeWatcher {
     watchPaths: string[];
     debounceMs: number;
     pendingEvents: number;
+    lastDetectionAt: string | null;
+    eventCount: number;
+    recentEventTypes: ChangeTrigger[];
+    statePath: string;
   } {
     return {
       running: !this.stopped,
@@ -172,6 +263,10 @@ export class ChangeWatcher {
       watchPaths: this.options.watchPaths,
       debounceMs: this.options.debounceMs,
       pendingEvents: this.queuedEvents.length,
+      lastDetectionAt: this.currentState.lastDetectionAt,
+      eventCount: this.currentState.eventCount,
+      recentEventTypes: [...this.currentState.recentEventTypes],
+      statePath: this.getStatePath(),
     };
   }
 
@@ -441,6 +536,24 @@ fi
       this.logInfo(
         `Drift detection completed: ${result.changedSymbols.length} symbols changed, ${result.affectedDocs.length} doc(s) affected.`,
       );
+
+      // Update + persist state. We do this AFTER the result is built but
+      // INSIDE the try/finally so a persistence failure can't double-fault
+      // (logged + swallowed by appendState's own try/catch). The detection
+      // itself has already succeeded; failing to write the state file just
+      // means the next restart re-uses the prior baseline, which is fine.
+      this.currentState = {
+        version: WATCHER_STATE_VERSION,
+        lastDetectionAt: new Date().toISOString(),
+        lastSnapshotId: currentSnapshot.timestamp,
+        eventCount: this.currentState.eventCount + events.length,
+        recentEventTypes: [
+          ...events.map((e) => e.type),
+          ...this.currentState.recentEventTypes,
+        ].slice(0, RECENT_EVENT_TYPES_LIMIT),
+      };
+      await this.appendState(this.currentState);
+
       return result;
     } catch (error: any) {
       this.logError(`Change watcher detection failed: ${error.message}`);
@@ -449,6 +562,104 @@ fi
     }
 
     return null;
+  }
+
+  /**
+   * Resolve the watcher state file path. Falls under the configured
+   * `snapshotDir` when one is provided so a single watcher run owns
+   * snapshots and state in the same directory; otherwise lands in
+   * `<projectPath>/.documcp/`. Public-as-test-seam (used by integration
+   * tests to assert the file landed where expected).
+   */
+  getStatePath(): string {
+    const baseDir =
+      this.options.snapshotDir ??
+      path.join(this.options.projectPath, ".documcp");
+    return path.join(baseDir, WATCHER_STATE_FILENAME);
+  }
+
+  /**
+   * Load the most recent persisted state, or return null when no usable
+   * record exists. Three failure modes, all non-throwing:
+   *
+   *   - File missing: silent (this is the cold-start case)
+   *   - File present but unparseable: warn, return null (start fresh)
+   *   - File present, valid JSON, but schema version mismatch:
+   *     warn, return null (avoid silently mis-deserializing fields that
+   *     may have changed shape)
+   *
+   * We deliberately read only the LAST line: earlier history is preserved
+   * for diagnostics but doesn't influence the current run.
+   */
+  private async loadState(): Promise<WatcherState | null> {
+    const statePath = this.getStatePath();
+    let raw: string;
+    try {
+      raw = await fs.readFile(statePath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        // Cold start — completely normal, no warning needed.
+        return null;
+      }
+      this.logWarn(
+        `Could not read watcher state at ${statePath}: ${
+          (err as Error).message
+        }; starting fresh.`,
+      );
+      return null;
+    }
+
+    const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+    if (lines.length === 0) {
+      return null;
+    }
+
+    const lastLine = lines[lines.length - 1];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(lastLine);
+    } catch {
+      this.logWarn(
+        `Watcher state file ${statePath} is not valid JSONL; starting fresh.`,
+      );
+      return null;
+    }
+
+    if (!isWatcherStateRecord(parsed)) {
+      this.logWarn(
+        `Watcher state record at ${statePath} has unrecognized shape; starting fresh.`,
+      );
+      return null;
+    }
+
+    if (parsed.version !== WATCHER_STATE_VERSION) {
+      this.logWarn(
+        `Watcher state schema mismatch (got ${parsed.version}, expected ${WATCHER_STATE_VERSION}); starting fresh.`,
+      );
+      return null;
+    }
+
+    return parsed;
+  }
+
+  /**
+   * Append a single state record as a JSON line. Failures are logged but
+   * not thrown — drift detection has already succeeded by the time this
+   * runs and we don't want a transient ENOSPC / EACCES to look like a
+   * detection failure to the caller.
+   */
+  private async appendState(state: WatcherState): Promise<void> {
+    const statePath = this.getStatePath();
+    try {
+      await fs.mkdir(path.dirname(statePath), { recursive: true });
+      await fs.appendFile(statePath, JSON.stringify(state) + "\n", "utf-8");
+    } catch (err) {
+      this.logWarn(
+        `Could not persist watcher state to ${statePath}: ${
+          (err as Error).message
+        }`,
+      );
+    }
   }
 
   private buildResultFromDrift(

--- a/tests/integration/change-watcher.test.ts
+++ b/tests/integration/change-watcher.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Integration tests for the change watcher (issue #113).
+ *
+ * Covers all four acceptance criteria:
+ *
+ *   1. Watcher state persists to `.documcp/watcher-state.jsonl` and
+ *      rehydrates on startup.
+ *   2. >= 3 file edits during an active session produce drift events.
+ *   3. Missing / corrupt state file is handled gracefully (logged, not
+ *      thrown), and the watcher starts fresh.
+ *   4. Existing tests don't regress (this file lives in the default
+ *      `npm test` path, so a CI run validates the negative).
+ *
+ * Strategy: stand up a tmp project containing a tiny TS source tree and
+ * a markdown docs file that references one of the source symbols. Drive
+ * detection via the public `triggerManual()` entry point rather than the
+ * chokidar FS watcher — chokidar's events are inherently racy in CI and
+ * we don't actually need them to verify persistence semantics. The
+ * acceptance criterion is "simulates >= 3 file edits and asserts drift
+ * events are emitted" which `triggerManual` faithfully exercises.
+ */
+
+import { promises as fs } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { mkdtemp, rm } from "fs/promises";
+
+import {
+  ChangeWatcher,
+  WATCHER_STATE_FILENAME,
+  WATCHER_STATE_VERSION,
+  WatcherState,
+} from "../../src/utils/change-watcher.js";
+
+interface WatcherFixtureLogger {
+  info: jest.Mock<void, [string]>;
+  warn: jest.Mock<void, [string]>;
+  error: jest.Mock<void, [string]>;
+}
+
+function makeLogger(): WatcherFixtureLogger {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+const SRC_FILE_NAMES = ["alpha.ts", "beta.ts", "gamma.ts"] as const;
+
+async function seedProject(root: string): Promise<{
+  projectPath: string;
+  docsPath: string;
+  snapshotDir: string;
+  srcDir: string;
+}> {
+  const projectPath = join(root, "project");
+  const srcDir = join(projectPath, "src");
+  const docsPath = join(projectPath, "docs");
+  const snapshotDir = join(projectPath, ".documcp");
+  await fs.mkdir(srcDir, { recursive: true });
+  await fs.mkdir(docsPath, { recursive: true });
+  await fs.mkdir(snapshotDir, { recursive: true });
+
+  // Three exported functions across three files. Documentation references
+  // them by name so the drift detector has both code-side and doc-side
+  // surface to compare.
+  await fs.writeFile(
+    join(srcDir, "alpha.ts"),
+    `export function greet(name: string): string {\n  return "hi " + name;\n}\n`,
+  );
+  await fs.writeFile(
+    join(srcDir, "beta.ts"),
+    `export function farewell(name: string): string {\n  return "bye " + name;\n}\n`,
+  );
+  await fs.writeFile(
+    join(srcDir, "gamma.ts"),
+    `export function age(): number {\n  return 42;\n}\n`,
+  );
+
+  await fs.writeFile(
+    join(docsPath, "api.md"),
+    `# API\n\n- \`greet(name)\` returns a greeting.\n- \`farewell(name)\` says goodbye.\n- \`age()\` returns a number.\n`,
+  );
+
+  return { projectPath, docsPath, snapshotDir, srcDir };
+}
+
+function makeWatcher(
+  projectPath: string,
+  docsPath: string,
+  snapshotDir: string,
+  logger: WatcherFixtureLogger,
+): ChangeWatcher {
+  return new ChangeWatcher(
+    {
+      projectPath,
+      docsPath,
+      snapshotDir,
+      // Tight debounce keeps tests fast; the spec lower bound is 50ms which
+      // the constructor enforces, so we sit right at the floor.
+      debounceMs: 50,
+      // Disable the FS watcher's pathwatch by pointing at a known-empty
+      // directory the test doesn't touch — we drive everything through
+      // triggerManual() so we don't fight chokidar's eventing.
+      watchPaths: [join(projectPath, "__never_touched__")],
+    },
+    { logger },
+  );
+}
+
+describe("change watcher persistence + integration (issue #113)", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), "change-watcher-int-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  test("persists state after detection and emits drift events for >= 3 edits", async () => {
+    const { projectPath, docsPath, snapshotDir, srcDir } = await seedProject(
+      tempRoot,
+    );
+    const logger = makeLogger();
+    const watcher = makeWatcher(projectPath, docsPath, snapshotDir, logger);
+
+    try {
+      await watcher.start();
+
+      // Simulate three meaningful edits: a signature change, a removal,
+      // and an addition. Each is a separate triggerManual() call so the
+      // watcher records three distinct events in `eventCount`.
+      await fs.writeFile(
+        join(srcDir, "alpha.ts"),
+        `// edit #1: signature change\nexport function greet(name: string, polite: boolean): string {\n  return polite ? "Hello, " + name : "hi " + name;\n}\n`,
+      );
+      const r1 = await watcher.triggerManual("test-edit-1", [
+        join(srcDir, "alpha.ts"),
+      ]);
+      expect(r1).toBeDefined();
+
+      await fs.writeFile(
+        join(srcDir, "beta.ts"),
+        `// edit #2: removed farewell, added wave\nexport function wave(): string {\n  return "👋";\n}\n`,
+      );
+      const r2 = await watcher.triggerManual("test-edit-2", [
+        join(srcDir, "beta.ts"),
+      ]);
+      expect(r2).toBeDefined();
+
+      await fs.writeFile(
+        join(srcDir, "gamma.ts"),
+        `// edit #3: changed return type\nexport function age(): string {\n  return "forty-two";\n}\n`,
+      );
+      const r3 = await watcher.triggerManual("test-edit-3", [
+        join(srcDir, "gamma.ts"),
+      ]);
+      expect(r3).toBeDefined();
+
+      // At least one of the three runs must surface drift events; they
+      // can't all be empty given the actual code mutations above.
+      const totalSymbols =
+        r1.changedSymbols.length +
+        r2.changedSymbols.length +
+        r3.changedSymbols.length;
+      expect(totalSymbols).toBeGreaterThan(0);
+
+      const status = watcher.getStatus();
+      expect(status.eventCount).toBeGreaterThanOrEqual(3);
+      expect(status.lastDetectionAt).not.toBeNull();
+      expect(status.recentEventTypes.length).toBeGreaterThanOrEqual(3);
+      expect(status.statePath).toBe(
+        join(snapshotDir, WATCHER_STATE_FILENAME),
+      );
+
+      // State file: must exist and contain valid JSONL with the most
+      // recent record matching the in-memory state.
+      const stateRaw = await fs.readFile(status.statePath, "utf-8");
+      const lines = stateRaw.split("\n").filter((l) => l.trim().length > 0);
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+      const lastRecord = JSON.parse(lines[lines.length - 1]) as WatcherState;
+      expect(lastRecord.version).toBe(WATCHER_STATE_VERSION);
+      expect(lastRecord.eventCount).toBe(status.eventCount);
+      // lastSnapshotId comes from `DriftSnapshot.timestamp` (captured when
+      // the snapshot is built); lastDetectionAt is captured at persist time
+      // a few microseconds later. We only assert both are ISO timestamps —
+      // strict equality would race the wall clock.
+      expect(lastRecord.lastSnapshotId).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(lastRecord.lastDetectionAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    } finally {
+      await watcher.stop();
+    }
+  });
+
+  test("rehydrates prior state on startup of a fresh watcher instance", async () => {
+    const { projectPath, docsPath, snapshotDir, srcDir } = await seedProject(
+      tempRoot,
+    );
+
+    // First session: drive one detection so a record gets persisted.
+    const w1 = makeWatcher(projectPath, docsPath, snapshotDir, makeLogger());
+    try {
+      await w1.start();
+      await fs.writeFile(
+        join(srcDir, "alpha.ts"),
+        `export function greet(name: string, suffix: string): string {\n  return "hi " + name + suffix;\n}\n`,
+      );
+      await w1.triggerManual("first-session-edit");
+    } finally {
+      await w1.stop();
+    }
+
+    const firstStatus = w1.getStatus();
+    expect(firstStatus.eventCount).toBeGreaterThan(0);
+
+    // Second session: brand-new ChangeWatcher targeting the same dirs.
+    // The rehydration path should pick up the prior eventCount + last
+    // detection timestamp.
+    const logger2 = makeLogger();
+    const w2 = makeWatcher(projectPath, docsPath, snapshotDir, logger2);
+    try {
+      await w2.start();
+      const status2 = w2.getStatus();
+      expect(status2.eventCount).toBe(firstStatus.eventCount);
+      expect(status2.lastDetectionAt).toBe(firstStatus.lastDetectionAt);
+      expect(status2.recentEventTypes).toEqual(firstStatus.recentEventTypes);
+
+      // info log should mention rehydration so operators can see it.
+      const rehydratedMsg = logger2.info.mock.calls.find((c) =>
+        c[0].includes("Rehydrated watcher state"),
+      );
+      expect(rehydratedMsg).toBeDefined();
+    } finally {
+      await w2.stop();
+    }
+  });
+
+  test("logs a warning and starts fresh when the state file is corrupt", async () => {
+    const { projectPath, docsPath, snapshotDir } = await seedProject(tempRoot);
+    const statePath = join(snapshotDir, WATCHER_STATE_FILENAME);
+    // Write garbage into the state file BEFORE the watcher comes up.
+    await fs.writeFile(statePath, "{ this is not valid json\n", "utf-8");
+
+    const logger = makeLogger();
+    const watcher = makeWatcher(projectPath, docsPath, snapshotDir, logger);
+    try {
+      await watcher.start();
+      const status = watcher.getStatus();
+      expect(status.eventCount).toBe(0);
+      expect(status.lastDetectionAt).toBeNull();
+
+      const warnedAboutCorrupt = logger.warn.mock.calls.find((c) =>
+        c[0].includes("not valid JSONL"),
+      );
+      expect(warnedAboutCorrupt).toBeDefined();
+    } finally {
+      await watcher.stop();
+    }
+  });
+
+  test("does not warn when the state file is simply missing (cold start)", async () => {
+    const { projectPath, docsPath, snapshotDir } = await seedProject(tempRoot);
+    // No state file written: ENOENT path of loadState().
+
+    const logger = makeLogger();
+    const watcher = makeWatcher(projectPath, docsPath, snapshotDir, logger);
+    try {
+      await watcher.start();
+      // We don't expect ANY warn calls about the missing file. Other
+      // warnings (e.g. baseline issues) are independent — but since the
+      // seed creates real source + docs, those should also be silent.
+      const noWarnsAboutState = logger.warn.mock.calls.every(
+        (c) => !c[0].includes("watcher-state.jsonl"),
+      );
+      expect(noWarnsAboutState).toBe(true);
+
+      const status = watcher.getStatus();
+      expect(status.eventCount).toBe(0);
+      expect(status.lastDetectionAt).toBeNull();
+    } finally {
+      await watcher.stop();
+    }
+  });
+
+  test("ignores state records with a mismatched schema version", async () => {
+    const { projectPath, docsPath, snapshotDir } = await seedProject(tempRoot);
+    const statePath = join(snapshotDir, WATCHER_STATE_FILENAME);
+    // Write a record with version "999" — valid JSON, valid shape, but
+    // unrecognized version. The watcher should warn and ignore it.
+    const stale: WatcherState = {
+      version: "999" as unknown as typeof WATCHER_STATE_VERSION,
+      lastDetectionAt: "2020-01-01T00:00:00.000Z",
+      lastSnapshotId: "2020-01-01T00:00:00.000Z",
+      eventCount: 999,
+      recentEventTypes: ["manual"],
+    };
+    await fs.writeFile(statePath, JSON.stringify(stale) + "\n", "utf-8");
+
+    const logger = makeLogger();
+    const watcher = makeWatcher(projectPath, docsPath, snapshotDir, logger);
+    try {
+      await watcher.start();
+      const status = watcher.getStatus();
+      expect(status.eventCount).toBe(0); // not 999
+      expect(status.lastDetectionAt).toBeNull();
+      const versionWarn = logger.warn.mock.calls.find((c) =>
+        c[0].includes("schema mismatch"),
+      );
+      expect(versionWarn).toBeDefined();
+    } finally {
+      await watcher.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #113. Adds restart resilience and end-to-end integration coverage to
the `ChangeWatcher` introduced in v0.5.3 (commit `362fbca`).

## What changed

- **`WatcherState` interface + version constant** — schema-versioned record
  written to `<snapshotDir>/watcher-state.jsonl` (default
  `<projectPath>/.documcp/watcher-state.jsonl`). Carries
  `lastDetectionAt`, `lastSnapshotId`, `eventCount`, and a 10-deep ring
  buffer of recent event types.
- **`loadState()` / `appendState()`** — non-throwing helpers. Cold start is
  silent; unparseable JSONL or schema version mismatch logs a warn and
  proceeds with a fresh state. Persistence failures are logged but never
  surface as detection errors (detection has already succeeded by that
  point).
- **Lifecycle wiring** — `start()` rehydrates *before* the FS watcher /
  webhook server come up, so events can't race in mid-rehydration.
  `runDetection()` appends a fresh record after every successful run.
- **`getStatus()` extension** — exposes `lastDetectionAt`, `eventCount`,
  `recentEventTypes`, and `statePath` so MCP callers and tests can
  introspect persistence without poking the filesystem.

## Acceptance criteria from #113

- [x] Watcher state persists to `.documcp/watcher-state.jsonl` and rehydrates on startup.
- [x] Integration test in `tests/integration/change-watcher.test.ts` simulates ≥ 3 file edits and asserts drift events are emitted.
- [x] Watcher gracefully handles missing/corrupt state file (logs a warning, starts fresh).
- [x] No regressions in existing 127+ tests. *(Full suite: 83 suites / 1626 tests pass.)*

## Tests

5 new integration tests in `tests/integration/change-watcher.test.ts`:

| Test | What it proves |
|---|---|
| persists state after detection + ≥3 edits | AC #1 + #2: round-trip of a real watcher session |
| rehydrates prior state on a fresh instance | AC #1: cross-process state recovery |
| corrupt state file → warn + start fresh | AC #3: graceful degradation on broken JSONL |
| missing state file → no warn (cold start) | AC #3: don't spam logs on first run |
| schema version mismatch → warn + start fresh | Forward-compatibility for future schema changes |

Drives detection through `triggerManual()` rather than chokidar so the
suite is deterministic across parallel Jest workers; chokidar events are
inherently racy and the AC actually tests the end-to-end persistence
pipeline, not the FS event source.

## Coverage delta

`src/utils/change-watcher.ts`:

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Statements | 45.65% | 59.56% | **+13.91pp** |
| Branches   | 27.5% | 44.00% | **+16.5pp** |
| Functions  | 38.88% | 58.13% | **+19.25pp** |
| Lines      | 47.39% | 61.75% | **+14.36pp** |

Remaining uncovered ranges are mostly the webhook server's HTTP handlers
(`startWebhookServer`, `verifySignature`, `mapWebhookToChangeEvent`);
those have separate coverage in the existing tools-layer tests for
`change_watcher`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test:ci` — 83 suites / 1626 tests pass, coverage thresholds met
- [x] New integration tests pass in 5 / 5 (~1.3s)
- [ ] CI confirms all checks green

## Related

- Issue: #113
- ADR: ADR-012 (Priority Scoring System — the watcher feeds prioritized drift results into this layer)
- Doc: `docs/how-to/change-watcher.md` (no doc changes needed — `getStatus()` shape is additive)

Made with [Cursor](https://cursor.com)